### PR TITLE
docs: add Source column to skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ You pick the skills. You pick the scripts. You build a custom plugin. You instal
 
 A skill is a capability you load into your agent. Out of the box, AI Maestro comes with:
 
-| Skill | What your agent can do |
-|-------|----------------------|
-| **Agent Messaging** | Send and receive messages to other agents |
-| **Agent Management** | Create, rename, hibernate, wake up other agents |
-| **Memory Search** | Search through past conversations and remember context |
-| **Code Graph** | Understand how your codebase is connected |
-| **Docs Search** | Search auto-generated documentation |
-| **Planning** | Break down complex tasks and track progress |
+| Skill | What your agent can do | Source |
+|-------|----------------------|--------|
+| **Agent Messaging** | Send and receive messages to other agents | [agentmessaging/claude-plugin](https://github.com/agentmessaging/claude-plugin) |
+| **Agent Identity** | Passwordless OAuth 2.0 auth using Ed25519 keys | [agentmessaging/agent-identity](https://github.com/agentmessaging/agent-identity) |
+| **Agent Management** | Create, rename, hibernate, wake up other agents | Local (`src/`) |
+| **Memory Search** | Search through past conversations and remember context | Local (`src/`) |
+| **Code Graph** | Understand how your codebase is connected | Local (`src/`) |
+| **Docs Search** | Search auto-generated documentation | Local (`src/`) |
+| **Planning** | Break down complex tasks and track progress | Local (`src/`) |
+
+The **Source** column tells you where each skill lives. `Local` means it's in this repo's `src/` folder. Linked skills are pulled from external repos during build.
 
 But here's the thing — **you're not stuck with this list.**
 


### PR DESCRIPTION
## Summary
- Added a **Source** column to the skills table in README showing where each skill comes from
- External skills link to their upstream repos (e.g., `agentmessaging/claude-plugin`)
- Local skills show `Local (src/)`
- Users can now see at a glance which skills are external and click through to the source repos

## Before
| Skill | What your agent can do |
|-------|----------------------|
| Agent Messaging | Send and receive messages... |

## After
| Skill | What your agent can do | Source |
|-------|----------------------|--------|
| Agent Messaging | Send and receive messages... | [agentmessaging/claude-plugin](https://github.com/agentmessaging/claude-plugin) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)