### PR TITLE
feat: AID v0.2.0 — independent from AMP

### DIFF
--- a/plugins/ai-maestro/README.md
+++ b/plugins/ai-maestro/README.md
@@ -2,8 +2,8 @@
 
 Built from plugin.manifest.json with 3 sources.
 
-**Skills:** 7 | **Scripts:** 48
+**Skills:** 7 | **Scripts:** 50
 
-Built at: 2026-03-24T03:50:50Z
+Built at: 2026-03-24T06:03:39Z
 
 See the [main repo](https://github.com/23blocks-OS/ai-maestro-plugins) for source files and build instructions.

--- a/plugins/ai-maestro/scripts/aid-helper.sh
+++ b/plugins/ai-maestro/scripts/aid-helper.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+# =============================================================================
+# AID Helper Functions
+# Agent Identity Protocol - Core utilities for all AID scripts
+# =============================================================================
+#
+# Self-contained helper providing:
+# - OpenSSL auto-detection (macOS LibreSSL doesn't support Ed25519)
+# - Agent identity directory resolution
+# - Configuration loading
+# - Ed25519 signing
+#
+# Storage: ~/.agent-messaging/agents/<name-or-uuid>/
+#
+# AID is independent of AMP. If both are installed, they share the same
+# agent directory structure for interoperability.
+# =============================================================================
+
+# =============================================================================
+# OpenSSL Auto-Detection
+# =============================================================================
+# macOS ships with LibreSSL which doesn't support Ed25519.
+# We auto-detect a compatible OpenSSL binary (Homebrew or system).
+
+_detect_openssl() {
+    local candidates=(
+        "/usr/local/opt/openssl@3/bin/openssl"
+        "/opt/homebrew/opt/openssl@3/bin/openssl"
+        "/usr/local/opt/openssl/bin/openssl"
+        "/opt/homebrew/opt/openssl/bin/openssl"
+        "/home/linuxbrew/.linuxbrew/opt/openssl@3/bin/openssl"
+    )
+
+    # Quick check: if system openssl is OpenSSL 3.x+, Ed25519 is supported
+    if command -v openssl &>/dev/null; then
+        local ver
+        ver=$(openssl version 2>/dev/null || true)
+        if [[ "$ver" == OpenSSL\ 3.* ]] || [[ "$ver" == OpenSSL\ 1.1.1* ]]; then
+            echo "openssl"
+            return 0
+        fi
+    fi
+
+    # Search Homebrew paths
+    for candidate in "${candidates[@]}"; do
+        if [ -x "$candidate" ]; then
+            local ver
+            ver=$("$candidate" version 2>/dev/null || true)
+            if [[ "$ver" == OpenSSL\ 3.* ]] || [[ "$ver" == OpenSSL\ 1.1.1* ]]; then
+                echo "$candidate"
+                return 0
+            fi
+        fi
+    done
+
+    echo ""
+    return 1
+}
+
+# Detect once and cache
+OPENSSL_BIN=$(_detect_openssl 2>/dev/null || true)
+
+OPENSSL_AVAILABLE=true
+if [ -z "$OPENSSL_BIN" ]; then
+    OPENSSL_AVAILABLE=false
+fi
+
+require_openssl() {
+    if [ "$OPENSSL_AVAILABLE" != "true" ]; then
+        echo "Error: No Ed25519-capable OpenSSL found." >&2
+        echo "" >&2
+        echo "macOS ships with LibreSSL which lacks Ed25519 support." >&2
+        echo "Install OpenSSL 3 via Homebrew:" >&2
+        echo "  brew install openssl@3" >&2
+        echo "" >&2
+        exit 1
+    fi
+}
+
+# =============================================================================
+# Agent Directory Resolution
+# =============================================================================
+#
+# Each agent has its own directory at ~/.agent-messaging/agents/<name-or-uuid>/
+# containing keys/, config.json, api_registrations/, and tokens/.
+#
+# Resolution order:
+#   1. Explicit AMP_DIR env var (set by AI Maestro or AMP)
+#   2. CLAUDE_AGENT_ID env var -> ~/.agent-messaging/agents/<uuid>/
+#   3. CLAUDE_AGENT_NAME env var -> index lookup or name dir
+#   4. tmux session name -> index lookup or name dir
+#   5. Single agent auto-select (solo setups)
+#
+
+AID_AGENTS_BASE="${HOME}/.agent-messaging/agents"
+
+# Case-insensitive name-to-UUID lookup via .index.json
+_aid_index_lookup() {
+    local name="$1"
+    local index_file="${AID_AGENTS_BASE}/.index.json"
+    [ -f "$index_file" ] || return 1
+    local uuid
+    uuid=$(jq -r --arg name "$name" '.[$name] // empty' "$index_file" 2>/dev/null)
+    if [ -n "$uuid" ]; then echo "$uuid"; return 0; fi
+    # Case-insensitive fallback
+    local lower_name
+    lower_name=$(echo "$name" | tr '[:upper:]' '[:lower:]')
+    uuid=$(jq -r --arg name "$lower_name" \
+        'to_entries[] | select(.key | ascii_downcase == $name) | .value' \
+        "$index_file" 2>/dev/null | head -1)
+    if [ -n "$uuid" ]; then echo "$uuid"; return 0; fi
+    return 1
+}
+
+_resolve_agent_dir() {
+    # Already resolved
+    if [ -n "${AMP_DIR:-}" ] && [ -d "${AMP_DIR}" ]; then
+        return 0
+    fi
+
+    local _resolved=false
+
+    # Priority 1: AMP_DIR already set (by AMP, AI Maestro, or env)
+    if [ -n "${AMP_DIR:-}" ] && [ -d "${AMP_DIR}" ]; then
+        _resolved=true
+    fi
+
+    # Priority 2: CLAUDE_AGENT_ID env var (UUID -> direct directory)
+    if [ "$_resolved" = false ] && [ -n "${CLAUDE_AGENT_ID:-}" ]; then
+        AMP_DIR="${AID_AGENTS_BASE}/${CLAUDE_AGENT_ID}"
+        _resolved=true
+    fi
+
+    # Priority 3: CLAUDE_AGENT_NAME or tmux session name
+    if [ "$_resolved" = false ]; then
+        local _agent_name=""
+        if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
+            _agent_name="${CLAUDE_AGENT_NAME}"
+        elif [ -n "${TMUX:-}" ]; then
+            _agent_name=$(tmux display-message -p '#S' 2>/dev/null || true)
+            _agent_name="${_agent_name%_[0-9]*}"
+        fi
+
+        if [ -n "$_agent_name" ]; then
+            local _uuid
+            _uuid=$(_aid_index_lookup "$_agent_name" 2>/dev/null) || true
+            if [ -n "$_uuid" ]; then
+                AMP_DIR="${AID_AGENTS_BASE}/${_uuid}"
+            else
+                AMP_DIR="${AID_AGENTS_BASE}/${_agent_name}"
+            fi
+            _resolved=true
+        fi
+    fi
+
+    # Priority 4: Single agent auto-select
+    if [ "$_resolved" = false ]; then
+        local _index_file="${AID_AGENTS_BASE}/.index.json"
+        if [ -f "$_index_file" ]; then
+            local _count
+            _count=$(jq 'length' "$_index_file" 2>/dev/null || echo "0")
+            if [ "$_count" = "1" ]; then
+                local _uuid
+                _uuid=$(jq -r 'to_entries[0].value' "$_index_file" 2>/dev/null)
+                if [ -n "$_uuid" ]; then
+                    AMP_DIR="${AID_AGENTS_BASE}/${_uuid}"
+                    _resolved=true
+                fi
+            elif [ "$_count" != "0" ]; then
+                echo "Error: Multiple agents found. Set CLAUDE_AGENT_NAME or use --id <uuid>" >&2
+                echo "" >&2
+                echo "Available agents:" >&2
+                while IFS= read -r _entry; do
+                    local _e_name _e_uuid _e_addr=""
+                    _e_name=$(echo "$_entry" | jq -r '.key')
+                    _e_uuid=$(echo "$_entry" | jq -r '.value')
+                    local _e_cfg="${AID_AGENTS_BASE}/${_e_uuid}/config.json"
+                    if [ -f "$_e_cfg" ]; then
+                        _e_addr=$(jq -r '.agent.address // empty' "$_e_cfg" 2>/dev/null)
+                    fi
+                    if [ -n "$_e_addr" ]; then
+                        printf "  %-45s %s\n" "$_e_addr" "$_e_uuid" >&2
+                    else
+                        printf "  %-45s %s\n" "$_e_name" "$_e_uuid" >&2
+                    fi
+                done < <(jq -c 'to_entries[]' "$_index_file" 2>/dev/null)
+                exit 1
+            fi
+        else
+            # No index file — try finding any agent dir with config.json
+            if [ -d "$AID_AGENTS_BASE" ]; then
+                for _dir in "$AID_AGENTS_BASE"/*/; do
+                    if [ -f "${_dir}config.json" ] && [ -d "${_dir}keys" ]; then
+                        AMP_DIR="${_dir%/}"
+                        _resolved=true
+                        break
+                    fi
+                done
+            fi
+        fi
+    fi
+
+    if [ "$_resolved" = false ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Exported variables (set by load_config)
+AMP_DIR="${AMP_DIR:-}"
+AMP_KEYS_DIR=""
+AMP_AGENT_NAME=""
+AMP_ADDRESS=""
+AMP_FINGERPRINT=""
+AMP_CONFIG=""
+
+# =============================================================================
+# is_initialized — Check if an agent identity exists
+# =============================================================================
+
+is_initialized() {
+    _resolve_agent_dir 2>/dev/null || return 1
+    AMP_CONFIG="${AMP_DIR}/config.json"
+    AMP_KEYS_DIR="${AMP_DIR}/keys"
+    [ -f "${AMP_CONFIG}" ] && [ -f "${AMP_KEYS_DIR}/private.pem" ]
+}
+
+# =============================================================================
+# load_config — Load agent identity configuration
+# =============================================================================
+
+load_config() {
+    _resolve_agent_dir || {
+        echo "Error: No agent identity found." >&2
+        echo "Run: aid-init --auto" >&2
+        return 1
+    }
+
+    AMP_CONFIG="${AMP_DIR}/config.json"
+    AMP_KEYS_DIR="${AMP_DIR}/keys"
+
+    if [ ! -f "$AMP_CONFIG" ]; then
+        echo "Error: Config file not found: ${AMP_CONFIG}" >&2
+        return 1
+    fi
+
+    AMP_AGENT_NAME=$(jq -r '.agent.name // .name // .agent_name // empty' "$AMP_CONFIG" 2>/dev/null)
+    AMP_ADDRESS=$(jq -r '.agent.address // .address // .amp_address // empty' "$AMP_CONFIG" 2>/dev/null)
+    AMP_FINGERPRINT=$(jq -r '.agent.fingerprint // .fingerprint // empty' "$AMP_CONFIG" 2>/dev/null)
+
+    # Compute fingerprint from public key if not in config
+    if [ -z "$AMP_FINGERPRINT" ] && [ -f "${AMP_KEYS_DIR}/public.pem" ]; then
+        require_openssl
+        AMP_FINGERPRINT=$($OPENSSL_BIN pkey -pubin -in "${AMP_KEYS_DIR}/public.pem" -outform DER 2>/dev/null | \
+            $OPENSSL_BIN dgst -sha256 -binary | base64)
+        AMP_FINGERPRINT="SHA256:${AMP_FINGERPRINT}"
+    fi
+
+    if [ -z "${AMP_AGENT_NAME}" ]; then
+        echo "Error: Agent name not found in config" >&2
+        return 1
+    fi
+}
+
+# =============================================================================
+# sign_message — Ed25519 sign a message, return base64-encoded signature
+# =============================================================================
+
+sign_message() {
+    require_openssl
+    local message="$1"
+    local private_key="${AMP_KEYS_DIR}/private.pem"
+
+    if [ ! -f "${private_key}" ]; then
+        echo "Error: No private key found at ${private_key}" >&2
+        return 1
+    fi
+
+    # Use temporary files (OpenSSL 3.x has issues with Ed25519 + stdin)
+    local tmp_msg tmp_sig
+    tmp_msg=$(mktemp)
+    tmp_sig=$(mktemp)
+    trap 'rm -f "$tmp_msg" "$tmp_sig"' RETURN
+
+    echo -n "${message}" > "$tmp_msg"
+    if $OPENSSL_BIN pkeyutl -sign -inkey "${private_key}" -rawin -in "$tmp_msg" -out "$tmp_sig" 2>/dev/null; then
+        base64 < "$tmp_sig" | tr -d '\n'
+    fi
+}
+
+# =============================================================================
+# generate_keypair — Create Ed25519 key pair
+# =============================================================================
+
+generate_keypair() {
+    require_openssl
+
+    local keys_dir="${1:-${AMP_KEYS_DIR}}"
+    mkdir -p "$keys_dir"
+
+    local private_key="${keys_dir}/private.pem"
+    local public_key="${keys_dir}/public.pem"
+
+    $OPENSSL_BIN genpkey -algorithm Ed25519 -out "${private_key}" 2>/dev/null
+    chmod 600 "${private_key}"
+
+    $OPENSSL_BIN pkey -in "${private_key}" -pubout -out "${public_key}" 2>/dev/null
+    chmod 644 "${public_key}"
+
+    # Calculate fingerprint
+    local fingerprint
+    fingerprint=$($OPENSSL_BIN pkey -in "${private_key}" -pubout -outform DER 2>/dev/null | \
+                  $OPENSSL_BIN dgst -sha256 -binary | base64)
+
+    echo "SHA256:${fingerprint}"
+}

--- a/plugins/ai-maestro/scripts/aid-init.sh
+++ b/plugins/ai-maestro/scripts/aid-init.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# =============================================================================
+# AID Init — Initialize Agent Identity
+# =============================================================================
+#
+# Create an Ed25519 identity for this agent. Generates a keypair and config
+# at ~/.agent-messaging/agents/<name>/.
+#
+# If AMP is also installed, both protocols share the same identity directory.
+# If AMP is not installed, AID works standalone.
+#
+# Usage:
+#   aid-init --auto                  # Auto-detect name from environment
+#   aid-init --name my-agent         # Specify agent name
+#
+# =============================================================================
+
+set -e
+
+# Source AID helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/aid-helper.sh"
+
+# =============================================================================
+# Arguments
+# =============================================================================
+
+AGENT_NAME=""
+AUTO_MODE=false
+FORCE=false
+
+show_help() {
+    echo "Usage: aid-init [options]"
+    echo ""
+    echo "Initialize an Ed25519 identity for this agent."
+    echo ""
+    echo "Options:"
+    echo "  --auto              Auto-detect agent name from environment"
+    echo "  --name, -n NAME    Specify agent name"
+    echo "  --force, -f        Overwrite existing identity"
+    echo "  --help, -h         Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  aid-init --auto"
+    echo "  aid-init --name support-agent"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --auto)
+            AUTO_MODE=true
+            shift
+            ;;
+        --name|-n)
+            AGENT_NAME="$2"
+            shift 2
+            ;;
+        --force|-f)
+            FORCE=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# =============================================================================
+# Resolve Agent Name
+# =============================================================================
+
+if [ "$AUTO_MODE" = true ] && [ -z "$AGENT_NAME" ]; then
+    # Try environment variables
+    if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
+        AGENT_NAME="$CLAUDE_AGENT_NAME"
+    elif [ -n "${TMUX:-}" ]; then
+        AGENT_NAME=$(tmux display-message -p '#S' 2>/dev/null || true)
+        AGENT_NAME="${AGENT_NAME%_[0-9]*}"
+    fi
+
+    # Fallback: hostname-based
+    if [ -z "$AGENT_NAME" ]; then
+        AGENT_NAME="agent-$(hostname -s 2>/dev/null | tr '[:upper:]' '[:lower:]' || echo 'default')"
+    fi
+fi
+
+if [ -z "$AGENT_NAME" ]; then
+    echo "Error: Agent name required. Use --name <name> or --auto" >&2
+    exit 1
+fi
+
+# Sanitize name (lowercase, alphanumeric + hyphens)
+AGENT_NAME=$(echo "$AGENT_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+
+echo ""
+echo "Initializing Agent Identity..."
+echo "  Name: ${AGENT_NAME}"
+echo ""
+
+# =============================================================================
+# Check Existing Identity
+# =============================================================================
+
+AGENT_DIR="${AID_AGENTS_BASE}/${AGENT_NAME}"
+
+if [ -f "${AGENT_DIR}/config.json" ] && [ "$FORCE" != true ]; then
+    echo "Agent identity already exists at ${AGENT_DIR}" >&2
+    echo "" >&2
+    echo "  Use --force to overwrite, or use the existing identity." >&2
+    echo "  Current identity:" >&2
+    echo "    Name:        $(jq -r '.agent.name // .name // "?"' "${AGENT_DIR}/config.json" 2>/dev/null)" >&2
+    echo "    Address:     $(jq -r '.agent.address // .address // "?"' "${AGENT_DIR}/config.json" 2>/dev/null)" >&2
+    echo "    Fingerprint: $(jq -r '.agent.fingerprint // .fingerprint // "?"' "${AGENT_DIR}/config.json" 2>/dev/null)" >&2
+    exit 1
+fi
+
+# =============================================================================
+# Generate Identity
+# =============================================================================
+
+require_openssl
+
+mkdir -p "${AGENT_DIR}/keys"
+mkdir -p "${AGENT_DIR}/api_registrations"
+mkdir -p "${AGENT_DIR}/tokens"
+
+echo "  Generating Ed25519 keypair..."
+AMP_KEYS_DIR="${AGENT_DIR}/keys"
+FINGERPRINT=$(generate_keypair "${AMP_KEYS_DIR}")
+
+# Build address
+TENANT="${AGENT_TENANT:-default}"
+ADDRESS="${AGENT_NAME}@${TENANT}.local"
+
+# Save config (compatible with AMP format)
+jq -n \
+    --arg name "$AGENT_NAME" \
+    --arg tenant "$TENANT" \
+    --arg address "$ADDRESS" \
+    --arg fingerprint "$FINGERPRINT" \
+    --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+        version: "1.0",
+        agent: {
+            name: $name,
+            tenant: $tenant,
+            address: $address,
+            fingerprint: $fingerprint,
+            createdAt: $created
+        }
+    }' > "${AGENT_DIR}/config.json"
+
+# Update index file for multi-agent resolution
+INDEX_FILE="${AID_AGENTS_BASE}/.index.json"
+if [ -f "$INDEX_FILE" ]; then
+    jq --arg name "$AGENT_NAME" --arg dir "$AGENT_NAME" '. + {($name): $dir}' "$INDEX_FILE" > "${INDEX_FILE}.tmp"
+    mv "${INDEX_FILE}.tmp" "$INDEX_FILE"
+else
+    jq -n --arg name "$AGENT_NAME" --arg dir "$AGENT_NAME" '{($name): $dir}' > "$INDEX_FILE"
+fi
+
+# Write human-readable identity file
+cat > "${AGENT_DIR}/IDENTITY.md" <<EOF
+# Agent Identity
+
+- **Name**: ${AGENT_NAME}
+- **Address**: ${ADDRESS}
+- **Fingerprint**: ${FINGERPRINT}
+- **Created**: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- **Key Algorithm**: Ed25519
+
+## Public Key
+
+\`\`\`
+$(cat "${AMP_KEYS_DIR}/public.pem")
+\`\`\`
+EOF
+
+echo "  Identity created."
+echo ""
+echo "  Agent:       ${AGENT_NAME}"
+echo "  Address:     ${ADDRESS}"
+echo "  Fingerprint: ${FINGERPRINT}"
+echo "  Directory:   ${AGENT_DIR}"
+echo ""
+echo "  Next steps:"
+echo "    # Register with an auth server"
+echo "    aid-register --auth https://auth.example.com/tenant \\"
+echo "      --token <admin_jwt> --role-id 2"
+echo ""
+echo "    # Or check your identity"
+echo "    aid-status"

--- a/plugins/ai-maestro/scripts/aid-register.sh
+++ b/plugins/ai-maestro/scripts/aid-register.sh
@@ -3,7 +3,7 @@
 # AID Register - Agent Identity Registration
 # =============================================================================
 #
-# Register this agent's AMP identity with a 23blocks Auth server for API access.
+# Register this agent's identity with a 23blocks Auth server for API access.
 # This is a one-time setup that links the agent's Ed25519 identity to a
 # company tenant with a specific role and permissions.
 #
@@ -12,16 +12,16 @@
 #   aid-register --auth https://auth.23blocks.com/acme --token <admin_jwt> --role-id 2 --api-key pk_live_xxx
 #
 # Prerequisites:
-#   - AMP identity initialized (amp-init --auto)
+#   - Agent identity initialized (aid-init --auto)
 #   - Admin JWT token for the target auth server
 #
 # =============================================================================
 
 set -e
 
-# Source AMP helper for identity, keys, and signing
+# Source AID helper for identity, keys, and signing
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/amp-helper.sh"
+source "${SCRIPT_DIR}/aid-helper.sh"
 
 # =============================================================================
 # Arguments
@@ -48,7 +48,7 @@ show_help() {
     echo ""
     echo "Options:"
     echo "  --api-key, -k KEY       API key (X-Api-Key header)"
-    echo "  --name, -n NAME         Display name (default: AMP agent name)"
+    echo "  --name, -n NAME         Display name (default: agent name)"
     echo "  --description, -d DESC  Agent description"
     echo "  --lifetime, -l SECS     Token lifetime in seconds (default: 3600)"
     echo "  --help, -h              Show this help"
@@ -125,12 +125,12 @@ if [ -z "$ROLE_ID" ]; then
 fi
 
 # =============================================================================
-# Load AMP Identity
+# Load Agent Identity
 # =============================================================================
 
 if ! is_initialized; then
-    echo "Error: AMP identity not initialized." >&2
-    echo "Run: amp-init --auto" >&2
+    echo "Error: Agent identity not initialized." >&2
+    echo "Run: aid-init --auto" >&2
     exit 1
 fi
 
@@ -139,7 +139,7 @@ load_config
 PUBLIC_KEY="${AMP_KEYS_DIR}/public.pem"
 
 if [ ! -f "$PUBLIC_KEY" ]; then
-    echo "Error: AMP public key not found at ${PUBLIC_KEY}" >&2
+    echo "Error: Public key not found at ${PUBLIC_KEY}" >&2
     exit 1
 fi
 

--- a/plugins/ai-maestro/scripts/aid-status.sh
+++ b/plugins/ai-maestro/scripts/aid-status.sh
@@ -3,7 +3,7 @@
 # AID Status - Agent Identity Status
 # =============================================================================
 #
-# Show registered auth servers, cached tokens, and AMP identity info.
+# Show registered auth servers, cached tokens, and agent identity info.
 #
 # Usage:
 #   aid-status              # Human-readable output
@@ -13,9 +13,9 @@
 
 set -e
 
-# Source AMP helper for identity
+# Source AID helper for identity
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/amp-helper.sh"
+source "${SCRIPT_DIR}/aid-helper.sh"
 
 FORMAT="text"
 
@@ -47,7 +47,7 @@ done
 # =============================================================================
 
 if ! is_initialized; then
-    echo "Error: AMP identity not initialized. Run: amp-init --auto" >&2
+    echo "Error: Agent identity not initialized. Run: aid-init --auto" >&2
     exit 1
 fi
 
@@ -76,7 +76,7 @@ if [ -d "$AID_CACHE_DIR" ]; then
     for token_file in "$AID_CACHE_DIR"/*.json; do
         [ -f "$token_file" ] || continue
         expires_at=$(jq -r '.expires_at // 0' "$token_file" 2>/dev/null)
-        auth_server=$(jq -r '.auth_server // .gateway // "?"' "$token_file" 2>/dev/null)
+        auth_server=$(jq -r '.auth_server // "?"' "$token_file" 2>/dev/null)
         scope=$(jq -r '.scope // ""' "$token_file" 2>/dev/null)
 
         if [ "$expires_at" -gt "$NOW" ] 2>/dev/null; then
@@ -121,7 +121,7 @@ else
 
     echo "  Auth Server Registrations: ${REG_COUNT}"
     if [ "$REG_COUNT" -gt 0 ]; then
-        echo "$REGISTRATIONS" | jq -r '.[] | "    - \(.auth_server // .gateway) (role: \(.role_id), status: \(.status))"'
+        echo "$REGISTRATIONS" | jq -r '.[] | "    - \(.auth_server) (role: \(.role_id), status: \(.status))"'
     else
         echo "    (none — run: aid-register --auth <url> --token <jwt> --role-id <id>)"
     fi

--- a/plugins/ai-maestro/scripts/aid-token.sh
+++ b/plugins/ai-maestro/scripts/aid-token.sh
@@ -3,7 +3,7 @@
 # AID Token - Agent Identity
 # =============================================================================
 #
-# Request an API token from a 23blocks Auth server using AMP identity.
+# Request an API token from a 23blocks Auth server using Agent Identity.
 # The agent presents its Agent Identity + proof of possession and receives
 # an RS256 JWT that works with any 23blocks API (or any JWT-validating API).
 #
@@ -13,16 +13,16 @@
 #   aid-token --auth https://auth.23blocks.com/acme --json
 #
 # Prerequisites:
-#   - AMP identity initialized (amp-init --auto)
+#   - Agent identity initialized (aid-init --auto)
 #   - Agent registered with the auth server (aid-register)
 #
 # =============================================================================
 
 set -e
 
-# Source AMP helper for identity, keys, and signing
+# Source AID helper for identity, keys, and signing
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/amp-helper.sh"
+source "${SCRIPT_DIR}/aid-helper.sh"
 
 # =============================================================================
 # Arguments
@@ -37,7 +37,7 @@ QUIET=false
 show_help() {
     echo "Usage: aid-token --auth <url> [options]"
     echo ""
-    echo "Request an API token from a 23blocks Auth server using AMP identity."
+    echo "Request an API token from a 23blocks Auth server using Agent Identity."
     echo ""
     echo "Required:"
     echo "  --auth, -a URL          Auth server URL (e.g., https://auth.23blocks.com/acme)"
@@ -102,12 +102,12 @@ if [ -z "$AUTH_URL" ]; then
 fi
 
 # =============================================================================
-# Load AMP Identity
+# Load Agent Identity
 # =============================================================================
 
 if ! is_initialized; then
-    echo "Error: AMP identity not initialized." >&2
-    echo "Run: amp-init --auto" >&2
+    echo "Error: Agent identity not initialized." >&2
+    echo "Run: aid-init --auto" >&2
     exit 1
 fi
 
@@ -118,7 +118,7 @@ PRIVATE_KEY="${AMP_KEYS_DIR}/private.pem"
 PUBLIC_KEY="${AMP_KEYS_DIR}/public.pem"
 
 if [ ! -f "$PRIVATE_KEY" ] || [ ! -f "$PUBLIC_KEY" ]; then
-    echo "Error: AMP keys not found at ${AMP_KEYS_DIR}/" >&2
+    echo "Error: Agent keys not found at ${AMP_KEYS_DIR}/" >&2
     exit 1
 fi
 
@@ -354,7 +354,7 @@ else
         case "$ERROR" in
             invalid_grant)
                 echo "  → Agent Identity signature may be invalid or expired." >&2
-                echo "    Check that your AMP keys match the registration." >&2
+                echo "    Check that your agent keys match the registration." >&2
                 ;;
             invalid_proof)
                 echo "  → Proof of possession failed. Check system clock sync." >&2

--- a/plugins/ai-maestro/skills/agent-identity/SKILL.md
+++ b/plugins/ai-maestro/skills/agent-identity/SKILL.md
@@ -1,53 +1,43 @@
 ---
 name: agent-identity
-description: Authenticate AI agents with auth servers using the Agent Identity (AID) protocol. Supports Ed25519 identity documents, proof of possession, OAuth 2.0 token exchange, and scoped JWT tokens. Works with any AI agent that can execute shell commands.
+description: Authenticate AI agents with auth servers using the Agent Identity (AID) protocol. Supports Ed25519 identity documents, proof of possession, OAuth 2.0 token exchange, and scoped JWT tokens. Self-contained — works independently without other protocols.
 license: MIT
-compatibility: Requires curl, jq, openssl, and base64 CLI tools. macOS and Linux supported. Scripts are POSIX-compatible bash.
+compatibility: Requires curl, jq, openssl (3.x for Ed25519), and base64 CLI tools. macOS and Linux supported.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
   homepage: "https://agentids.org"
   repository: "https://github.com/agentmessaging/agent-identity"
 ---
 
 # Agent Identity (AID) Protocol
 
-Authenticate AI agents with auth servers using cryptographic identity documents and proof of possession.
+Authenticate AI agents with auth servers using cryptographic identity documents and proof of possession. AID is self-contained — no other protocols required.
 
 ## When to use this skill
 
 Use this skill when the user or task requires:
+- Initializing an agent's Ed25519 identity
 - Registering an agent's identity with an auth server
 - Obtaining JWT tokens for API access via token exchange
 - Checking an agent's AID registration status
 - Setting up agent-to-server authentication
 - Configuring scoped permissions for agent API access
 
-## Prerequisites
-
-AID builds on AMP (Agent Messaging Protocol). The agent must be initialized with AMP first:
-
-```bash
-# Ensure AMP identity exists
-amp-identity.sh
-# If not initialized:
-amp-init.sh --auto
-```
-
-The agent's AMP Ed25519 keypair is reused for AID authentication.
-
 ## Quick Start
 
 ```bash
-# 1. Register with an auth server (one-time)
-aid-register.sh --server https://api.example.com --tenant acme --api-key pk_live_xxx
+# 1. Initialize agent identity (one-time)
+aid-init.sh --auto
 
-# 2. Get a JWT token
-TOKEN=$(aid-token.sh --server https://api.example.com)
+# 2. Register with an auth server (one-time, requires admin token)
+aid-register.sh --auth https://auth.23blocks.com/acme \
+  --token <ADMIN_JWT> --role-id 2
 
-# 3. Use it for API calls
-curl -H "Authorization: Bearer $TOKEN" \
-     -H "X-Api-Key: pk_live_xxx" \
-     https://api.example.com/users
+# 3. Get a JWT token
+TOKEN=$(aid-token.sh --auth https://auth.23blocks.com/acme --quiet)
+
+# 4. Use it for API calls
+curl -H "Authorization: Bearer $TOKEN" https://api.example.com/resource
 ```
 
 ## Installation
@@ -58,9 +48,13 @@ curl -H "Authorization: Bearer $TOKEN" \
 npx skills add agentmessaging/agent-identity
 ```
 
-### Manual
+### Quick Install
 
-Clone the repo and add `scripts/` to your PATH:
+```bash
+curl -fsSL https://raw.githubusercontent.com/agentmessaging/agent-identity/main/install.sh | bash
+```
+
+### Manual
 
 ```bash
 git clone https://github.com/agentmessaging/agent-identity.git ~/agent-identity
@@ -69,67 +63,78 @@ export PATH="$HOME/agent-identity/scripts:$PATH"
 
 ## Commands Reference
 
-### aid-register.sh — Register Agent Identity
+### aid-init.sh — Initialize Agent Identity
 
-Registers the agent's public key and identity with an auth server's OIDC endpoint.
+Create an Ed25519 keypair and identity for this agent.
 
 ```bash
-aid-register.sh --server https://api.example.com --tenant acme --api-key pk_live_xxx
-aid-register.sh -s https://api.example.com -t acme -k pk_live_xxx
-aid-register.sh --server https://api.example.com --tenant acme --api-key pk_live_xxx --scopes "read:users write:users"
+aid-init.sh --auto              # Auto-detect name from environment
+aid-init.sh --name my-agent     # Specify agent name
+aid-init.sh --name my-agent --force  # Overwrite existing
 ```
 
 **Parameters:**
-- `--server, -s` — Auth server base URL (required)
-- `--tenant, -t` — Tenant/company identifier (required)
-- `--api-key, -k` — API key for the tenant (required)
-- `--scopes` — Space-separated list of requested scopes (optional)
+- `--auto` — Auto-detect agent name from environment
+- `--name, -n` — Specify agent name
+- `--force, -f` — Overwrite existing identity
+
+### aid-register.sh — Register with Auth Server
+
+One-time registration linking the agent's Ed25519 identity to a tenant with a specific role.
+
+```bash
+aid-register.sh --auth https://auth.23blocks.com/acme \
+  --token <ADMIN_JWT> --role-id 2
+```
+
+**Parameters:**
+- `--auth, -a` — Auth server URL (required)
+- `--token, -t` — Admin JWT for authorization (required)
+- `--role-id, -r` — Role ID to assign (required)
+- `--api-key, -k` — API key (X-Api-Key header)
+- `--name, -n` — Display name (default: agent name)
+- `--description, -d` — Agent description
+- `--lifetime, -l` — Token lifetime in seconds (default: 3600)
 
 **What it does:**
-1. Reads the agent's AMP public key and identity
-2. Creates an Agent Identity Document (signed JSON)
-3. POSTs the registration to the server's agent registration endpoint
-4. Stores the registration locally for future token exchanges
+1. Reads the agent's Ed25519 public key and identity
+2. POSTs the registration to the server's agent registration endpoint
+3. Stores the registration locally for future token exchanges
 
 ### aid-token.sh — Exchange Identity for JWT Token
 
 Performs the OAuth 2.0 token exchange using `grant_type=urn:aid:agent-identity`.
 
 ```bash
-# Get a token (uses stored registration)
-aid-token.sh --server https://api.example.com
+# Get a token (uses cache if valid)
+aid-token.sh --auth https://auth.23blocks.com/acme
+
+# Get just the token string (for scripting)
+TOKEN=$(aid-token.sh --auth https://auth.23blocks.com/acme --quiet)
 
 # Get a token with specific scopes
-aid-token.sh --server https://api.example.com --scopes "read:users"
-
-# Output just the token (for scripting)
-TOKEN=$(aid-token.sh --server https://api.example.com --quiet)
+aid-token.sh --auth https://auth.23blocks.com/acme --scope "files:read files:write"
 ```
 
 **Parameters:**
-- `--server, -s` — Auth server base URL (required)
-- `--scopes` — Request specific scopes (optional, defaults to registered scopes)
-- `--quiet, -q` — Output only the token string (for variable assignment)
+- `--auth, -a` — Auth server URL (required)
+- `--scope, -s` — Space-separated scopes (optional)
+- `--json, -j` — Output as JSON
+- `--quiet, -q` — Output only the token string
+- `--no-cache` — Skip token cache
 
 **What it does:**
 1. Builds a fresh Agent Identity Document with current timestamp
 2. Creates a Proof of Possession (`aid-token-exchange\n{timestamp}\n{auth_issuer}`)
 3. Signs the proof with the agent's Ed25519 private key
-4. POSTs to the OIDC token endpoint with `grant_type=urn:aid:agent-identity`
-5. Returns the JWT access token
+4. POSTs to the OAuth token endpoint with `grant_type=urn:aid:agent-identity`
+5. Returns the JWT access token (cached for reuse)
 
-**Token details:**
-- RS256 JWT signed by the auth server's company RSA key
-- Contains `token_type: "agent"`, `sub: "agent:{uuid}"`
-- Short-lived (typically 15-60 minutes)
-- Scoped permissions based on agent registration
-
-### aid-status.sh — Check Registration Status
+### aid-status.sh — Check Identity & Registration Status
 
 ```bash
-aid-status.sh                              # Show all registrations
-aid-status.sh --server https://api.example.com  # Check specific server
-aid-status.sh --json                       # JSON output
+aid-status.sh          # Human-readable output
+aid-status.sh --json   # JSON output
 ```
 
 ## How AID Authentication Works
@@ -140,12 +145,14 @@ A signed JSON document proving the agent's identity:
 
 ```json
 {
-  "aid_version": "0.1",
-  "address": "my-agent@org.aimaestro.local",
-  "public_key": "MCowBQYDK2VwAyEA...",
+  "aid_version": "1.0",
+  "address": "support-agent@default.local",
+  "alias": "support-agent",
+  "public_key": "-----BEGIN PUBLIC KEY-----\n...",
+  "key_algorithm": "Ed25519",
   "fingerprint": "SHA256:abc123...",
   "issued_at": "2026-03-23T00:00:00Z",
-  "expires_at": "2026-03-23T01:00:00Z",
+  "expires_at": "2026-09-23T00:00:00Z",
   "signature": "base64-ed25519-signature"
 }
 ```
@@ -155,49 +162,56 @@ A signed JSON document proving the agent's identity:
 The agent signs a challenge proving it holds the private key:
 
 ```
-aid-token-exchange\n{timestamp}\n{auth_issuer}
+aid-token-exchange\n{timestamp}\n{auth_server_url}
 ```
 
 ### Step 3: Token Exchange
 
 ```
 POST /oauth/token
-grant_type=urn:aid:agent-identity
-agent_identity={base64-identity-document}
-proof={base64-signed-proof}
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn%3Aaid%3Aagent-identity
+&agent_identity={base64url-identity-document}
+&proof={base64url-signed-proof}
 ```
 
 ### Step 4: Use the JWT
 
-The server returns a standard OAuth 2.0 response with a JWT access token.
+The server returns a standard OAuth 2.0 response with an RS256 JWT access token. Use it with any API that validates JWTs via the auth server's JWKS endpoint.
 
 ## Natural Language Examples
 
 Agents should map these user intents to the appropriate commands:
 
-- "Register with the API" → `aid-register.sh --server <url> --tenant <t> --api-key <k>`
-- "Get me an API token" → `aid-token.sh --server <url>`
-- "Check my registrations" → `aid-status.sh`
-- "Authenticate with the auth server" → `aid-token.sh --server <url>`
-- "What servers am I registered with?" → `aid-status.sh`
+- "Initialize my identity" -> `aid-init.sh --auto`
+- "Register with the API" -> `aid-register.sh --auth <url> --token <jwt> --role-id <id>`
+- "Get me an API token" -> `aid-token.sh --auth <url>`
+- "Check my registrations" -> `aid-status.sh`
+- "Authenticate with the auth server" -> `aid-token.sh --auth <url>`
 
 ## Security
 
+- **Self-contained** — no external protocol dependencies
 - **Ed25519 signatures** — identity documents are cryptographically signed
 - **Proof of possession** — agents prove key ownership at every token exchange
+- **Human-controlled access** — admin creates roles and registers agents
 - **Short-lived tokens** — JWTs expire quickly, limiting blast radius
 - **No shared secrets** — private keys never leave the agent
-- **Scoped access** — tokens carry only the permissions the agent needs
-- **Fingerprint binding** — server verifies the agent's key fingerprint matches registration
+- **Scoped access** — tokens carry only the permissions the agent's role allows
+
+## Interoperability
+
+AID shares the `~/.agent-messaging/agents/` directory with [AMP](https://agentmessaging.org) if both are installed. One identity serves both protocols. Neither requires the other.
 
 ## Troubleshooting
 
 | Problem | Solution |
 |---------|----------|
-| "AMP not initialized" | Run `amp-init.sh --auto` first |
-| "Not registered" | Run `aid-register.sh` with server details |
+| "Agent identity not initialized" | Run `aid-init.sh --auto` |
+| "Not registered" | Run `aid-register.sh` with auth server details |
 | "Proof expired" | Clock skew >5 minutes; sync system clock |
-| "Invalid signature" | Agent identity may be corrupted; re-register |
+| "Invalid signature" | Agent identity may be corrupted; re-init and re-register |
 | "Fingerprint mismatch" | Agent key changed since registration; re-register |
 | "Scope not allowed" | Request only scopes granted during registration |
 


### PR DESCRIPTION
## Summary
- Rebuilt plugin with AID v0.2.0 (commit 549f3c4)
- AID is now fully standalone — no longer requires AMP
- New scripts: `aid-helper.sh`, `aid-init.sh`
- All `aid-*` scripts now source `aid-helper.sh` instead of `amp-helper.sh`
- Plugin: 7 skills, **50 scripts** (was 48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)