### PR TITLE
fix: AMP v0.1.3 upstream fixes — mesh routing, fetch URLs, timestamps

### DIFF
--- a/plugins/ai-maestro/README.md
+++ b/plugins/ai-maestro/README.md
@@ -4,6 +4,6 @@ Built from plugin.manifest.json with 3 sources.
 
 **Skills:** 7 | **Scripts:** 50
 
-Built at: 2026-03-24T06:03:39Z
+Built at: 2026-03-25T05:57:54Z
 
 See the [main repo](https://github.com/23blocks-OS/ai-maestro-plugins) for source files and build instructions.

--- a/plugins/ai-maestro/scripts/amp-fetch.sh
+++ b/plugins/ai-maestro/scripts/amp-fetch.sh
@@ -131,10 +131,10 @@ for provider in "${PROVIDERS[@]}"; do
     EXTERNAL_ADDRESS=$(echo "$REGISTRATION" | jq -r '.address')
 
     # Use explicit fetchUrl from registration if available, otherwise derive from apiUrl
-    # All providers use the same AMP standard: GET /messages/pending
+    # All providers use the same AMP standard: GET /v1/messages/pending
     FETCH_ENDPOINT=$(echo "$REGISTRATION" | jq -r '.fetchUrl // empty')
     if [ -z "$FETCH_ENDPOINT" ]; then
-        FETCH_ENDPOINT="${API_URL}/messages/pending"
+        FETCH_ENDPOINT="${API_URL}/v1/messages/pending"
     fi
 
     if [ "$VERBOSE" = true ]; then
@@ -298,10 +298,10 @@ for provider in "${PROVIDERS[@]}"; do
 
             TOTAL_NEW=$((TOTAL_NEW + 1))
 
-            # Acknowledge receipt on provider (AMP standard: DELETE /messages/pending/:id)
+            # Acknowledge receipt on provider (AMP standard: DELETE /v1/messages/pending/:id)
             if [ "$MARK_AS_FETCHED" = true ]; then
                 # msg_id is validated to [a-zA-Z0-9_-] so safe in path segment
-                curl -s --connect-timeout 3 -X DELETE "${API_URL}/messages/pending/${msg_id}" \
+                curl -s --connect-timeout 3 -X DELETE "${API_URL}/v1/messages/pending/${msg_id}" \
                     -H "Authorization: Bearer ${API_KEY}" \
                     >/dev/null 2>&1 || true
             fi

--- a/plugins/ai-maestro/scripts/amp-helper.sh
+++ b/plugins/ai-maestro/scripts/amp-helper.sh
@@ -958,16 +958,9 @@ build_address() {
 
 # Generate message ID
 generate_message_id() {
-    # macOS date doesn't support %N (nanoseconds), so use python/perl fallback
+    # AMP spec: msg_<seconds_timestamp>_<hex_random>
     local timestamp
-    if timestamp=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null); then
-        : # got millisecond timestamp
-    elif timestamp=$(perl -e 'use Time::HiRes qw(time); printf "%d\n", time()*1000' 2>/dev/null); then
-        : # got millisecond timestamp via perl
-    else
-        # Fallback: seconds with random suffix for uniqueness (IMPL-05)
-        timestamp="$(date +%s)000"
-    fi
+    timestamp=$(date +%s)
     local random
     random=$(head -c 4 /dev/urandom | xxd -p)
     echo "msg_${timestamp}_${random}"

--- a/plugins/ai-maestro/scripts/amp-send.sh
+++ b/plugins/ai-maestro/scripts/amp-send.sh
@@ -475,7 +475,7 @@ if [ "$ROUTE" = "local" ]; then
             RECIPIENT_AMP_DIR="${AGENTS_BASE_DIR}/${ADDR_NAME}"
         fi
 
-        if [ -d "${RECIPIENT_AMP_DIR}" ]; then
+        if [ -d "${RECIPIENT_AMP_DIR}" ] && [ -f "${RECIPIENT_AMP_DIR}/config.json" ]; then
             # Recipient IS on this machine — deliver directly via filesystem
             save_to_sent "$MESSAGE_JSON" >/dev/null
             MSG_ID=$(echo "$MESSAGE_JSON" | jq -r '.envelope.id')
@@ -628,7 +628,7 @@ if [ "$ROUTE" = "local" ]; then
                 RECIPIENT_AMP_DIR="${AGENTS_BASE_DIR}/${ADDR_NAME}"
             fi
 
-            if [ -d "${RECIPIENT_AMP_DIR}" ]; then
+            if [ -d "${RECIPIENT_AMP_DIR}" ] && [ -f "${RECIPIENT_AMP_DIR}/config.json" ]; then
                 # Recipient IS on this machine - filesystem delivery is valid
                 save_to_sent "$MESSAGE_JSON" >/dev/null
                 MSG_ID=$(echo "$MESSAGE_JSON" | jq -r '.envelope.id')


### PR DESCRIPTION
## Summary

Rebuilt plugin from upstream `agentmessaging/claude-plugin` main, pulling 3 critical fixes:

- **amp-send.sh** (PR #15): Check `config.json` before filesystem delivery — fixes mesh routing broken after message migration created local directories for remote agents
- **amp-fetch.sh** (PR #14): Add missing `/v1/` prefix to fetch and acknowledge URLs (was causing 404s against Crabmail)
- **amp-helper.sh** (PR #14): `generate_message_id()` uses seconds-precision timestamps per AMP spec (was milliseconds)

## Test plan

- [ ] `amp-send.sh` to remote agent routes via mesh (not local filesystem)
- [ ] `amp-fetch.sh` successfully fetches from external providers
- [ ] Message IDs use seconds format: `msg_<seconds>_<hex>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)