### PR TITLE
feat: multi-agent hook support (Claude, Codex, Gemini)

### DIFF
--- a/plugins/ai-maestro/scripts/ai-maestro-hook.cjs
+++ b/plugins/ai-maestro/scripts/ai-maestro-hook.cjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 /**
- * AI Maestro Claude Code Hook
+ * AI Maestro Agent Hook
  *
- * This hook captures Claude Code events and writes state to files
- * that AI Maestro can read to display in the Chat interface.
+ * Universal hook for AI coding agents (Claude Code, Codex CLI, Gemini CLI).
+ * Captures agent events, writes state for the Chat interface, and injects
+ * AMP inbox notifications via each agent's native context injection.
  *
- * Supported events:
- * - Notification (idle_prompt): When Claude is waiting for user input
- * - Stop: When Claude finishes responding
- * - SessionStart: When a session starts/resumes
+ * Supported agents and their event mappings:
+ *   Claude Code: Stop, Notification(idle_prompt), SessionStart
+ *   Codex CLI:   Stop, SessionStart
+ *   Gemini CLI:  AfterAgent, Notification, SessionStart
  *
  * State is written to: ~/.aimaestro/chat-state/<cwd-hash>.json
  */
@@ -121,6 +122,47 @@ function debugLog(data) {
     fs.appendFileSync(debugFile, line);
 }
 
+// Detect which AI agent is calling this hook
+function detectAgent(input) {
+    // Gemini CLI sets GEMINI_SESSION_ID or has gemini-specific fields
+    if (process.env.GEMINI_SESSION_ID || process.env.GEMINI_PROJECT_DIR) return 'gemini';
+    // Codex CLI sets model field with gpt- prefix or has turn_id
+    if (input.model && input.model.startsWith('gpt-')) return 'codex';
+    if (input.turn_id !== undefined) return 'codex';
+    // Default to Claude Code
+    return 'claude';
+}
+
+// Normalize event names across agents to our internal names
+function normalizeEvent(hookEvent, agent) {
+    // Gemini's AfterAgent = Claude/Codex's Stop
+    if (agent === 'gemini' && hookEvent === 'AfterAgent') return 'Stop';
+    return hookEvent;
+}
+
+// Build the context injection response in the correct format for each agent
+function buildContextResponse(agent, hookEvent, message) {
+    if (!message) return {};
+
+    switch (agent) {
+        case 'codex':
+            // Codex CLI uses systemMessage field
+            return { systemMessage: message };
+        case 'gemini':
+            // Gemini CLI uses systemMessage or additionalContext
+            return { systemMessage: message };
+        case 'claude':
+        default:
+            // Claude Code uses hookSpecificOutput.additionalContext
+            return {
+                hookSpecificOutput: {
+                    hookEventName: hookEvent,
+                    additionalContext: message
+                }
+            };
+    }
+}
+
 // Check for unread messages using AMP CLI (standalone — no AI Maestro needed)
 async function checkUnreadMessagesStandalone() {
     const { execSync } = require('child_process');
@@ -223,12 +265,16 @@ async function main() {
     // Log all input for debugging
     debugLog({ event: 'hook_received', input });
 
-    const hookEvent = input.hook_event_name || process.env.CLAUDE_HOOK_EVENT;
-    const cwd = input.cwd || process.cwd();
+    const agent = detectAgent(input);
+    const rawEvent = input.hook_event_name || process.env.CLAUDE_HOOK_EVENT;
+    const hookEvent = normalizeEvent(rawEvent, agent);
+    const cwd = input.cwd || process.env.GEMINI_CWD || process.cwd();
     const sessionId = input.session_id;
     const transcriptPath = input.transcript_path;
 
-    // Hook response — may be enriched with additionalContext for inbox notifications
+    debugLog({ event: 'agent_detected', agent, rawEvent, hookEvent });
+
+    // Hook response — may be enriched with context injection for inbox notifications
     let hookResponse = {};
 
     // Handle different hook events
@@ -316,16 +362,11 @@ async function main() {
                     transcriptPath
                 });
 
-                // Check for unread messages and inject as additionalContext
+                // Check for unread messages and inject as context
                 const idleMessagePrompt = await checkUnreadMessages(cwd);
                 if (idleMessagePrompt) {
-                    debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'idle_prompt' });
-                    hookResponse = {
-                        hookSpecificOutput: {
-                            hookEventName: 'Notification',
-                            additionalContext: idleMessagePrompt
-                        }
-                    };
+                    debugLog({ event: 'injecting_inbox_context', cwd, agent, trigger: 'idle_prompt' });
+                    hookResponse = buildContextResponse(agent, rawEvent, idleMessagePrompt);
                 }
             } else if (notificationType === 'permission_prompt') {
                 // For permission prompts, preserve existing tool info if we have it
@@ -381,16 +422,11 @@ async function main() {
                 source: input.source
             });
 
-            // Check for unread messages and inject as additionalContext
+            // Check for unread messages and inject as context
             const startMessagePrompt = await checkUnreadMessages(cwd);
             if (startMessagePrompt) {
-                debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'session_start' });
-                hookResponse = {
-                    hookSpecificOutput: {
-                        hookEventName: 'SessionStart',
-                        additionalContext: startMessagePrompt
-                    }
-                };
+                debugLog({ event: 'injecting_inbox_context', cwd, agent, trigger: 'session_start' });
+                hookResponse = buildContextResponse(agent, rawEvent, startMessagePrompt);
             }
             break;
 

--- a/src/scripts/ai-maestro-hook.cjs
+++ b/src/scripts/ai-maestro-hook.cjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 /**
- * AI Maestro Claude Code Hook
+ * AI Maestro Agent Hook
  *
- * This hook captures Claude Code events and writes state to files
- * that AI Maestro can read to display in the Chat interface.
+ * Universal hook for AI coding agents (Claude Code, Codex CLI, Gemini CLI).
+ * Captures agent events, writes state for the Chat interface, and injects
+ * AMP inbox notifications via each agent's native context injection.
  *
- * Supported events:
- * - Notification (idle_prompt): When Claude is waiting for user input
- * - Stop: When Claude finishes responding
- * - SessionStart: When a session starts/resumes
+ * Supported agents and their event mappings:
+ *   Claude Code: Stop, Notification(idle_prompt), SessionStart
+ *   Codex CLI:   Stop, SessionStart
+ *   Gemini CLI:  AfterAgent, Notification, SessionStart
  *
  * State is written to: ~/.aimaestro/chat-state/<cwd-hash>.json
  */
@@ -121,6 +122,47 @@ function debugLog(data) {
     fs.appendFileSync(debugFile, line);
 }
 
+// Detect which AI agent is calling this hook
+function detectAgent(input) {
+    // Gemini CLI sets GEMINI_SESSION_ID or has gemini-specific fields
+    if (process.env.GEMINI_SESSION_ID || process.env.GEMINI_PROJECT_DIR) return 'gemini';
+    // Codex CLI sets model field with gpt- prefix or has turn_id
+    if (input.model && input.model.startsWith('gpt-')) return 'codex';
+    if (input.turn_id !== undefined) return 'codex';
+    // Default to Claude Code
+    return 'claude';
+}
+
+// Normalize event names across agents to our internal names
+function normalizeEvent(hookEvent, agent) {
+    // Gemini's AfterAgent = Claude/Codex's Stop
+    if (agent === 'gemini' && hookEvent === 'AfterAgent') return 'Stop';
+    return hookEvent;
+}
+
+// Build the context injection response in the correct format for each agent
+function buildContextResponse(agent, hookEvent, message) {
+    if (!message) return {};
+
+    switch (agent) {
+        case 'codex':
+            // Codex CLI uses systemMessage field
+            return { systemMessage: message };
+        case 'gemini':
+            // Gemini CLI uses systemMessage or additionalContext
+            return { systemMessage: message };
+        case 'claude':
+        default:
+            // Claude Code uses hookSpecificOutput.additionalContext
+            return {
+                hookSpecificOutput: {
+                    hookEventName: hookEvent,
+                    additionalContext: message
+                }
+            };
+    }
+}
+
 // Check for unread messages using AMP CLI (standalone — no AI Maestro needed)
 async function checkUnreadMessagesStandalone() {
     const { execSync } = require('child_process');
@@ -223,12 +265,16 @@ async function main() {
     // Log all input for debugging
     debugLog({ event: 'hook_received', input });
 
-    const hookEvent = input.hook_event_name || process.env.CLAUDE_HOOK_EVENT;
-    const cwd = input.cwd || process.cwd();
+    const agent = detectAgent(input);
+    const rawEvent = input.hook_event_name || process.env.CLAUDE_HOOK_EVENT;
+    const hookEvent = normalizeEvent(rawEvent, agent);
+    const cwd = input.cwd || process.env.GEMINI_CWD || process.cwd();
     const sessionId = input.session_id;
     const transcriptPath = input.transcript_path;
 
-    // Hook response — may be enriched with additionalContext for inbox notifications
+    debugLog({ event: 'agent_detected', agent, rawEvent, hookEvent });
+
+    // Hook response — may be enriched with context injection for inbox notifications
     let hookResponse = {};
 
     // Handle different hook events
@@ -316,16 +362,11 @@ async function main() {
                     transcriptPath
                 });
 
-                // Check for unread messages and inject as additionalContext
+                // Check for unread messages and inject as context
                 const idleMessagePrompt = await checkUnreadMessages(cwd);
                 if (idleMessagePrompt) {
-                    debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'idle_prompt' });
-                    hookResponse = {
-                        hookSpecificOutput: {
-                            hookEventName: 'Notification',
-                            additionalContext: idleMessagePrompt
-                        }
-                    };
+                    debugLog({ event: 'injecting_inbox_context', cwd, agent, trigger: 'idle_prompt' });
+                    hookResponse = buildContextResponse(agent, rawEvent, idleMessagePrompt);
                 }
             } else if (notificationType === 'permission_prompt') {
                 // For permission prompts, preserve existing tool info if we have it
@@ -381,16 +422,11 @@ async function main() {
                 source: input.source
             });
 
-            // Check for unread messages and inject as additionalContext
+            // Check for unread messages and inject as context
             const startMessagePrompt = await checkUnreadMessages(cwd);
             if (startMessagePrompt) {
-                debugLog({ event: 'injecting_inbox_context', cwd, trigger: 'session_start' });
-                hookResponse = {
-                    hookSpecificOutput: {
-                        hookEventName: 'SessionStart',
-                        additionalContext: startMessagePrompt
-                    }
-                };
+                debugLog({ event: 'injecting_inbox_context', cwd, agent, trigger: 'session_start' });
+                hookResponse = buildContextResponse(agent, rawEvent, startMessagePrompt);
             }
             break;
 


### PR DESCRIPTION
## Summary
- Hook script now auto-detects which AI agent is calling it (Claude Code, Codex CLI, Gemini CLI)
- Returns the correct context injection format for each agent's hook system
- All three agents get AMP inbox notifications between turns

## Agent Detection
| Signal | Agent |
|---|---|
| `GEMINI_SESSION_ID` or `GEMINI_PROJECT_DIR` env var | Gemini CLI |
| `model` starts with `gpt-` or `turn_id` in stdin | Codex CLI |
| Default | Claude Code |

## Response Format
| Agent | Format |
|---|---|
| Claude Code | `{ hookSpecificOutput: { hookEventName, additionalContext } }` |
| Codex CLI | `{ systemMessage }` |
| Gemini CLI | `{ systemMessage }` |

## Event Normalization
Gemini AfterAgent is mapped to Stop internally so the same handler logic works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)